### PR TITLE
Update ServerGameState_Scripting.cpp

### DIFF
--- a/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
+++ b/code/components/citizen-server-impl/src/state/ServerGameState_Scripting.cpp
@@ -352,6 +352,21 @@ static void Init()
 		return nullptr;
 	}));
 
+	fx::ScriptEngine::RegisterNativeHandler("GET_OBJECT_TYPE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity) -> const char*
+	{
+		switch (entity->type)
+		{
+			case fx::sync::NetObjEntityType::Object:
+				return "Object";
+			case fx::sync::NetObjEntityType::Door:
+				return "Door";
+			case fx::sync::NetObjEntityType::Pickup:
+				return "Pickup";
+		}
+
+		return nullptr;
+	}));
+
 	fx::ScriptEngine::RegisterNativeHandler("GET_ENTITY_TYPE", makeEntityFunction([](fx::ScriptContext& context, const fx::sync::SyncEntityPtr& entity)
 	{
 		switch (entity->type)


### PR DESCRIPTION
its, useful because models of PICKUP on server-side are 0 so its hard to define which object is pickup and which is not